### PR TITLE
PyQt Journal Window files

### DIFF
--- a/JournalList.ui
+++ b/JournalList.ui
@@ -1,0 +1,179 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>JournalList</class>
+ <widget class="QDialog" name="JournalList">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>522</width>
+    <height>417</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>CaptsLog Journal List</string>
+  </property>
+  <layout class="QGridLayout">
+   <property name="margin">
+    <number>9</number>
+   </property>
+   <property name="spacing">
+    <number>6</number>
+   </property>
+   <item row="4" column="6" colspan="2">
+    <widget class="QTextEdit" name="notesTextEdit">
+     <property name="tabChangesFocus">
+      <bool>true</bool>
+     </property>
+     <property name="lineWrapMode">
+      <enum>QTextEdit::NoWrap</enum>
+     </property>
+     <property name="acceptRichText">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="4">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>&amp;Length:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="8" colspan="2">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_5">
+     <property name="text">
+      <string>&amp;Journal List</string>
+     </property>
+     <property name="buddy">
+      <cstring>notesTextEdit</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="6">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>&amp;Date:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>&amp;Title:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="4">
+    <widget class="QPlainTextEdit" name="plainTextEdit_2"/>
+   </item>
+   <item row="4" column="0" colspan="4">
+    <widget class="QPlainTextEdit" name="plainTextEdit"/>
+   </item>
+   <item row="3" column="8">
+    <widget class="QLabel" name="label_6">
+     <property name="text">
+      <string>Tags:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="8">
+    <widget class="QPlainTextEdit" name="plainTextEdit_3"/>
+   </item>
+   <item row="2" column="4">
+    <widget class="QToolButton" name="toolButton">
+     <property name="text">
+      <string>Save</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="2">
+    <widget class="QToolButton" name="toolButton_5">
+     <property name="text">
+      <string>File</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="3">
+    <widget class="QToolButton" name="toolButton_6">
+     <property name="text">
+      <string>View</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="4">
+    <widget class="QToolButton" name="toolButton_7">
+     <property name="text">
+      <string>Edit</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="3">
+    <widget class="QToolButton" name="toolButton_4">
+     <property name="text">
+      <string>Open</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="2">
+    <widget class="QToolButton" name="toolButton_2">
+     <property name="text">
+      <string>New</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="6">
+    <widget class="QToolButton" name="toolButton_3">
+     <property name="text">
+      <string>Convert</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>JournalList</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>342</x>
+     <y>396</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>367</x>
+     <y>414</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>JournalList</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>459</x>
+     <y>395</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>480</x>
+     <y>398</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/filemanagement.py
+++ b/filemanagement.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+#  filemanagement.py
+#  
+#  Copyright 2017 Roark <roark@roark-Satellite-A665>
+#  
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#  
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+#  MA 02110-1301, USA.
+#  
+#  
+
+import bisect
+import codecs								#The codecs library is used for reading/writing text files in Python
+import copy_reg								#Used for saving and loading files that contain arbitrary Python data structures
+import cPickle					
+import gzip									#Used to compress the text files and "Pickle" data
+from PyQt4.QtCore import *
+from PyQt4.QtXml import *
+
+CODEC = "UTF-8"								#UTF-8 bit codec for text files
+NEWPARA = UNICHR(0x2029)					#One byte for each ASCII Character, 2 or more bytes for any other characters
+NEWLINE = UNICHR(0X2028)
+
+class Journal(object):
+	UNKNOWNDATA = 0000 
+	UNKNOWNLENGTH = 0
+	
+	def __init__(self, title = None, data = UNKNOWNDATA,
+	length = UNKNOWNLENGTH, lastupdated = None, notes = None):
+		
+		self.title = title
+		self.data = data
+		self.length = length
+		self.lastupdated = lastupdated \
+			if lastupdated is not None else QDate.currentDate()
+		self.notes = notes
+
+class JournalContainer(object):
+	MAGIC_NUMBER = 0x3051E					#Magic Number and File Version are constants used for saving and loading files
+	FILE_VERSION = 100						#Using PyQt's QDataStream class
+	
+	def __init__(self):			
+		self.__fname = Qstring()			#Journal's file name is held as a Qstring() function
+		self.journals = []					#
+		self.__journalFromId = {}
+		self.__dirty = False
+	
+	def __iter__(self):
+		for pair in iter(self.__journals):	#Iterates over the ordered list of journals and returns the journal items for each entry
+			yield pair[1]
+	
+	def __len__(self):
+		return len(self.__journals)
+		
+	def clear(self, clearFilename = True):	#This function clears the information from the Journal entry
+		self.__journals = []
+		self.__journalFromId = {}
+		if clearFilename:
+			self.__fname = Qstring()
+		self.__dirty = False
+		
+	def add(self, journal):					#This function adds a journal entry to the table
+		if id(journal) in self.__journalFromId:
+			return False
+		key = self.key(journal.title, journal.year)
+		bisect.insort_left(self.__journals, [key, journal])
+		self.__journalFromId[id(journal)] = journal
+		self.__dirty = True
+		return True
+	
+	def key(self, title, data):				#Keys are used to ensure that journal entries with the same title aren't entered twice.
+		text = unicode(title).lower()
+		if text.startswith("a "):
+			text = text[2:]
+		elif text.startswith("an "):
+			text = text[3:]
+		elif text.startswith("the "):
+			text = text[4:]
+		parts = text.split(" ", 1)
+		if parts[0].isdigit():
+			text = "%08d " % int(parts[0])
+			if len(parts) > 1:
+				text += parts[1]
+		return u"%s\t%d" % (text.replace(" ", ""), year)
+		
+		
+	
+	def delete(self, journal):
+		if id(journal) not in self.__journalFromId:
+			return False
+		key = self.key(journal.title, movie.data)
+		i = bisect.bisect_left(self.__journals, [key, journals])
+		del self.__journals[i]
+		del self.__journalFromId[id(journal)]
+		self.__dirty = True
+		return True
+	
+	def updateJournal(self, journal, title, data, length = None, notes = None): #After a journal has been deleted, the table needs to be updated
+		
+		if length is not None:
+			journal.length = length
+		if notes is not None:
+			journal.notes = notes
+		if title != journal.title or data != journal.date:
+			key = self.key(journal.title, journal.data)
+			i = bisect.bisect_left(self.__journals, [key, journal])
+			self.__journals[i][0] = self.key(title, data)
+			journal.title = title
+			journal.date = date
+			self.__journals.sort()
+		self.__dirty = True
+					
+	@staticmethod
+	def formats():							
+		return "*.mqb *. mpb *.mqt *.mpt "		#Data formats
+												#.mqb is Qt binary format
+												#.mpb is also Pickle python format
+												#.mqt is Qxt text format
+												#.mpt is Python text format
+	
+	def save(self, fname = Qstring()):			#File save function
+												#Depending on the file format, the proper PyQt save function will be called
+		if not fname.isEmpty():
+			self.__fname = fname
+		if self.__fname.endsWith(".mqb"):
+			return self.saveQDataStream()
+		elif self.__fname.endsWith(".mpb"):
+			return self.savePickle()
+		elif self.__fname.endsWith(".mqt"):
+			return self.saveQTextStream()
+		elif self.__fname.endsWith(".mpt"):
+			return self.saveText()
+		return False
+		
+	#def saveQDataStream(self):
+	#	error = None
+	#	fh = None
+	#	try:
+	#		fh = QFile(self.__fname)
+	#		if not fh.open(QIOD	
+		
+			
+	def saveQTextStream(self):
+		error = None 
+		fh = None
+		try:
+			fh = QFile(self.__fname)
+			if not fh.open(QIODevice.WriteOnly):
+				raise IOerror, unicode(fh.errorString())
+			stream = QTextStream(fh)
+			stream.setCodec(CODEC)
+			for key, journal in self.__journals:
+				stream << "{{JOURNAL}} " << journal.title << "\n" \
+					   << journal.date << " " << journal.length << " " \
+					   << journal.lastupdated.toString(Qt.ISODate) \
+					   << "\n{NOTES}"
+				if not journal.notes.isEmpty():
+					stream << "\" << journal.notes
+				stream << "\n {{ENDJOURNAL}}\N"
+	
+	def intFromQstr(qstr):
+		i, ok = qstr.toInt()
+		if not ok:
+			raise ValueError, unicode(qstr)
+		return i		
+# Refer back to page 251 
+def main():
+	
+	return 0
+
+if __name__ == '__main__':
+	main()
+

--- a/main.py
+++ b/main.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+#  main.py
+#  
+#  Copyright 2017 Roark <roark@roark-Satellite-A665>
+#  
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#  
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+#  MA 02110-1301, USA.
+#  
+#  
+
+#Import the libraries needed for PyQt
+import sys
+from PyQt4 import QtGui, QtCore
+from PyQt4.QtCore import Qt
+
+import markdown
+
+
+class Main(QtGui.QMainWindow):
+	
+	#Initialize the main window of the application 
+	def __init__(self, parent = None):
+		QtGui.QMainWindow.__init__(self, parent)
+		
+		self.filename = ""
+		
+		self.initUI()
+	
+	def initToolbar(self):
+	
+	#Initializes the toolbar menu options for New, Open, and Save functions
+	#Also sets their descriptions, shortcuts, and actions
+	
+		self.newAction = QtGui.QAction(QtGui.QIcon("images/filenew.png"), "New", self)
+		self.newAction.setStatusTip("Create a new Journal entry.")
+		self.newAction.setShortcut("Ctrl + N")
+		self.newAction.triggered.connect(self.new)
+	
+		self.openAction = QtGui.QAction(QtGui.QIcon("images/fileopen.png"), "Open file", self)
+		self.openAction.setStatusTip("Open existing journal entry")
+		self.openAction.setShortcut("Ctrl + O")
+		self.openAction.triggered.connect(self.open)
+	
+		self.saveAction = QtGui.QAction(QtGui.QIcon("images/filesave.png"), "Save", self)
+		self.saveAction.setStatusTip("Save journal entry")
+		self.saveAction.setShortcut("Ctrl + S")
+		self.saveAction.triggered.connect(self.save)
+	
+		#self.toolbar = self.addToolBar("Options")
+		
+		self.printAction = QtGui.QAction(QtGui.QIcon("images/fileopen.png"), "Print journal", self)
+		self.printAction.setStatusTip("Print journal entry")
+		self.printAction.setShortcut("Ctrl + P")
+		self.printAction.triggered.connect(self.printHandler)
+		
+		self.previewAction = QtGui.QAction(QtGui.QIcon("images/editcopy.png"), "Journal preview", self)
+		self.previewAction.setStatusTip("Preview journal before printing")
+		self.previewAction.setShortcut("Ctrl + Shift + P")
+		self.previewAction.triggered.connect(self.preview)
+		
+		self.cutAction = QtGui.QAction(QtGui.QIcon("images/editcut.png"), "Cut to clipboard", self)
+		self.cutAction.setStatusTip("Delete this text and copy the text to the clipboard")
+		self.cutAction.setShortcut("Ctrl + x")
+		self.cutAction.triggered.connect(self.text.cut)
+		
+		self.copyAction = QtGui.QAction(QtGui.QIcon("images/editcopy.png"), "Copy to the clipboard", self)
+		self.copyAction.setStatusTip("Copy text to the clipboard")
+		self.copyAction.setShortcut("Ctrl + C")
+		self.copyAction.triggered.connect(self.text.copy)
+		
+		self.pasteAction = QtGui.QAction(QtGui.QIcon("images/editpase.png"), "Paste from clipboard", self)
+		self.pasteAction.setStatusTip("Pastes text from the clipboard")
+		self.pasteAction.setShortcut("Ctrl + V")
+		self.pasteAction.triggered.connect(self.text.paste)
+		
+		self.undoAction = QtGui.QAction(QtGui.QIcon("images/editdelete.png"), "Undo last action", self)
+		self.undoAction.setStatusTip("Undo last action")
+		self.undoAction.setShortcut("Ctrl + Z")
+		self.undoAction.triggered.connect(self.text.undo)
+		
+		self.redoAction = QtGui.QAction(QtGui.QIcon("images/editdelete.png"), "Redo last action", self)
+		self.redoAction.setStatusTip("Redo last action")
+		self.redoAction.setShortcut("Ctrl + Y")
+		self.redoAction.triggered.connect(self.text.undo)
+		
+		bulletAction = QtGui.QAction(QtGui.QIcon("images/editdelete.png"), "Insert bulleted list", self)
+		bulletAction.setStatusTip("Insert bullet list")
+		bulletAction.setShortcut("Ctrl + Shift + B")
+		bulletAction.triggered.connect(self.bulletList)
+		
+		numberedAction = QtGui.QAction(QtGui.QIcon("images/editdelete.png"), "Insert numbered list", self)
+		numberedAction.setStatusTip("Insert numbered list")
+		numberedAction.setShortcut("Ctrl + Shift + L")
+		numberedAction.triggered.connect(self.numberList)
+		
+		headerAction = QtGui.QAction(QtGui.QIcon("images/editdelete.png"), "Insert title head", self)
+		headerAction.setStatusTip("Insert title headers")
+		headerAction.setShortcut("Ctrl + Shift + H")
+		headerAction.triggered.connect(self.header)
+		
+		emphasisAction = QtGui.QAction(QtGui.QIcon("images/editdelete.png"), "Put emphasis on the selected word", self)
+		emphasisAction.setStatusTip("Put emphasis on the selected word")
+		emphasisAction.setShortcut("Ctrl + Shift + E")
+		emphasisAction.triggered.connect(self.emphasis)
+		
+		self.toolbar = self.addToolBar("Options")
+	
+		self.toolbar.addAction(self.newAction)
+		self.toolbar.addAction(self.openAction)
+		self.toolbar.addAction(self.saveAction)
+	
+	#Formats and separates the toolbar menus
+		self.toolbar.addSeparator()
+		
+		self.toolbar.addAction(self.printAction)
+		self.toolbar.addAction(self.previewAction)
+		
+		self.toolbar.addSeparator()
+		
+		self.toolbar.addAction(self.cutAction)
+		self.toolbar.addAction(self.copyAction)
+		self.toolbar.addAction(self.pasteAction)
+		self.toolbar.addAction(self.undoAction)
+		self.toolbar.addAction(self.redoAction)
+		
+		self.toolbar.addSeparator()
+		
+		self.toolbar.addAction(bulletAction)
+		self.toolbar.addAction(numberedAction)
+		self.toolbar.addAction(headerAction)
+		self.toolbar.addAction(emphasisAction)
+		
+		
+		self.addToolBarBreak()
+		
+	def initFormatbar(self):
+	
+		#Creates a Format menu
+		self.formatbar = self.addToolBar("Format")
+		
+	def initMenubar(self):
+	
+		menubar = self.menuBar()
+	
+		#Creates objects for the toolbar menus
+		file = menubar.addMenu("File")
+		edit = menubar.addMenu("Edit")
+		view = menubar.addMenu("View")
+		
+		file.addAction(self.newAction)
+		file.addAction(self.openAction)
+		file.addAction(self.saveAction)
+		file.addAction(self.printAction)
+		file.addAction(self.previewAction)
+		
+		edit.addAction(self.undoAction)
+		edit.addAction(self.redoAction)
+		edit.addAction(self.cutAction)
+		edit.addAction(self.copyAction)
+		edit.addAction(self.pasteAction)
+
+	def initUI(self):
+		
+		self.text = QtGui.QTextEdit(self)
+		
+		self.initToolbar()
+		self.initFormatbar()
+		self.initMenubar()
+		
+		self.text.setTabStopWidth(33)
+		self.setCentralWidget(self.text)
+		#self.setCentralWidget(self.text)
+		
+		self.statusbar = self.statusBar()
+		self.text.cursorPositionChanged.connect(self.cursorPosition)
+		
+		self.setGeometry(100, 100, 1030, 800)
+		self.setWindowTitle("CaptsLog")
+		self.setWindowIcon(QtGui.QIcon("/images/icon.png"))
+		
+	def new(self):
+
+		spawn = Main(self)
+		spawn.show()
+
+	def open(self):
+
+		# Get filename and show only .markdown files
+		self.filename = QtGui.QFileDialog.getOpenFileName(self, 'Open File',".","(*.markdown)")
+
+		if self.filename:
+			with open(self.filename,"rt") as file:
+				self.text.setText(file.read())
+
+	def save(self):
+
+        # Only open dialog if there is no filename yet
+		if not self.filename:
+			self.filename = QtGui.QFileDialog.getSaveFileName(self, 'Save File')
+
+        # Append extension if not there yet
+	#	if not self.filename.endswith(".markdown"):
+	#		self.filename += ".markdown"
+
+        # We just store the contents of the text file along with the
+        # format in html, which Qt does in a very nice way for us
+		with open(self.filename,"wt") as file:
+			file.write(self.text.toHtml())
+
+	def preview(self):
+
+        # Open preview dialog
+		preview = QtGui.QPrintPreviewDialog()
+
+        # If a print is requested, open print dialog
+		preview.paintRequested.connect(lambda p: self.text.print_(p))
+
+		preview.exec_()
+
+	def printHandler(self):
+
+        # Open printing dialog
+		dialog = QtGui.QPrintDialog()
+
+		if dialog.exec_() == QtGui.QDialog.Accepted:
+			self.text.document().print_(dialog.printer())
+
+
+	def cursorPosition(self):
+
+		cursor = self.text.textCursor()
+
+        # Mortals like 1-indexed things
+		line = cursor.blockNumber() + 1
+		col = cursor.columnNumber()
+
+		self.statusbar.showMessage("Line: {} | Column: {}".format(line,col))
+
+	def bulletList(self):
+
+		cursor = self.text.textCursor()
+		cursor.insertText(markdown.markdown('*'))
+        # Insert bulleted list	
+		#cursor.insertList(QtGui.QTextListFormat.ListDisc)
+
+	def numberList(self):
+
+		cursor = self.text.textCursor()
+
+        # Insert list with numbers
+		cursor.insertList(QtGui.QTextListFormat.ListDecimal)
+
+	def header (self):
+		
+		cursor = self.text.textCursor()
+		cursor.insertText(markdown.markdown('#'))
+		
+	def emphasis (self):
+		
+		cursor = self.text.textCursor()
+		cursor.insertText(markdown.markdown('#'))
+		""" Function doc """
+class Preview(QtGui.QMainWindow):
+	
+	def __init__(prev, parent = None):
+		
+		QtGui.QMainWindow.__init__(prev, parent)
+		
+		prev.initUI()
+		
+		def initUI(prev):
+			prev.setGeometry(100, 100, 1030, 800)
+			prev.setWindowTitle("Journal Preview")
+			
+	
+			""" Function doc """
+			
+		""" Function doc """
+		
+	""" Function doc """
+			
+def main():
+
+	app = QtGui.QApplication(sys.argv)
+
+	main = Main()
+	main.show()
+
+	sys.exit(app.exec_())
+
+if __name__ == "__main__":
+	main()

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+#  mainwindow.py
+#  
+#  Copyright 2017 Roark <roark@roark-Satellite-A665>
+#  
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#  
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+#  MA 02110-1301, USA.
+#  
+#  
+
+import os
+import platform
+import sys
+from PyQt4.QtCore import *
+from PyQt4.QtGui import *
+import helpform
+import newimagedlg
+import qrc_resources
+
+_version_ = "1.0.0"
+
+class MainWindow(QMainWindow):		#Initial declaration of the Main Program window
+							
+	def __init__(self, parent = None): 
+		super(MainWindow, self).__init__(parent)
+		
+		self.journals = journaldata.JournalContainer()		#Create an empty container for the journals 	
+		self.table = QTableWidget()							#Create an empty table widget to present journal metadata
+		self.setCentralWidget(self.table)
+	
+	def updateTable(self, current = None):					#This function just updates the journal entry table.
+															#It can be called without arguments, which just updates the table with the newest info															#
+															#It can also be called with the ID of the current journal, in which case it selects that Journal entry in the table	
+		self.table.clear()
+		self.table.setRowCount(len(self.journal))
+		self.table.setColumnCount(5)
+		self.table.setHorizontalHeaderLabels(["Title", "Date", "Length", "LastUpdated", "Notes"])
+		self.table.setAlternatingRowColors(True)
+		self.table.setEditTriggers(QTableWidget.NoEditTriggers)
+		self.table.setSelectionBehavior(QTableWidget.SelectRows)
+		self.table.setSelectionMode(QTableWidget.SingleSelection)
+		selected = None
+		
+															#This for loop clears the table data/headings
+															#Then sets the row and column counts and headers
+															#Then it sets the rest of the journal settings
+		for row, journal in enumerate(self.journals):
+			item = QTableWidgetItem(journal.title)
+			if current is not None and current == id(journal):
+				selected = item
+			item.setData(Qt.UserRole, QVariant(long(id(journal))))
+			self.table.setItem(row, 0, item)
+			year = journal.year
+			
+			if year != journal.UNKNOWNYEAR:
+				item = QTableWidgetItem("%d" % year)
+				item.setTextAlignment(Qt.AlignCenter)
+				self.table.setItem(row, 1, item)
+			length = journal.length	
+			if length != journal.UNKNOWNLENGTH:
+				item = QTableWidgetItem("%d" % length)
+				item.setTextAlignment(Qt.AlignRight | Qt.AlignVCenter)
+				self.table.setItem(row, 2, item)
+			item = QTableWidgetItem(journal.acquired.toString(
+			journaldata.DATEFORMAT))
+			
+			item.setTextAlignment(Qt.AlignRight | Qt.AlignVCenter)
+			self.table.setItem(row, 3, item)
+			notes = journal.notes
+			if notes.length() > 40:
+				notes = notes.left(39) + "..."
+			self.table.setItem(row, 4, QTableWidgetItem(notes))
+			
+			self.table.resizeColumnsToContents()
+			if selected is not None:
+				selected.setSelected(True)
+				self.table.setCurrentItem(selected)
+				self.table.scrollToItem(selected)
+	def fileNew(self):										#This function just creates a new journal table entry
+															#Clears out the current journal data
+		if not self.okToContinue():
+			return
+		self.journals.clear()
+		self.statusBar().clearMessage()
+		self.updateTable()
+		
+	def fileOpen(self):
+		if not self.okToContinue():
+			return
+		path = QFileInfo(self.journals.filename()).path() \
+		if not self.journals.filename().isEMpty() else "."
+	frame = QFileDialog.getOpenFileName(self, 
+		"My Journals -- Load Journal Data", path,
+		"My Journal's data files (%s)" % \
+		self.journals.formats())
+	if not fname.isEmpty():
+		of, msg = self.journals.load(fname)
+		self.statusBar().showMessage(msg, 5000)
+		self.updateTable()
+	
+	def fileSave(self):
+		if self.journals.filename().isEmpty():
+			self.fileSaveAs()
+		else:
+			ok, msg = self.journals.save()
+			self.statusBar().showMessage(msg, 5000)
+			
+	def fileImportDOM(self):
+		self.fileImport("dom")
+		
+	def fileImportSAX(self):
+		self.fileImport("sax")
+		
+	def fileImport(self, format):
+		if not self.okToContinue():
+			return
+		path = QFileInfo(self.journals.filename()).path() \
+			if not self.journals.filename().isEmpty() else "."
+		fname = QFileDialog.getOpenFileName(self, 
+			"My Journals -- Import Journal Data", path,
+			"My Journals XML files (*.xml)")
+		if not fname.isEmpty():
+				if format == "dom":
+					ok, msg = self.journals.importDOM(fname)
+				else:
+					ok, msg = self.journals.importSAX(fname)
+				self.statusBar().showMessage(msg, 5000)
+				self.updateTable()
+				
+	def fileExportXml(self):
+		
+		fname = self.journals.filename()
+		if fname.isEmpty():
+			fname = "."
+		else:
+			i = fname.lastIndex0f(".")
+			if i > 0:
+				fname = fname.left(i)
+			fname += ".xml"
+		fname = QFileDialog.getSaveFileName(self,
+			"My Journals -- Export Journal Data", fname,
+			"My Journal's XML files (*.xml)")
+		if not fname.isEmpty():
+			if not fname.contains("."):
+				fname += ".xml"
+			ok, msg = self.journals.exportXml(fname)
+			self.statusBar().showMessage(msg, 5000)
+		
+				
+			 
+			
+			
+		
+		
+		
+def main():
+	
+	return 0
+
+if __name__ == '__main__':
+	main()
+


### PR DESCRIPTION
JournalList.ui is a Qt Designer template file that contains a basic template of the journal list with the journal title and info. 

Filemanagement.py is for processing the text from a journal entry into the journal preview fields.

main.py is a basic PyQt texteditor I was working with.

mainwindow.py is a journal table for creating and displaying journal entries.
Example:

git commit -m "ThingsthatIdid" (NO)
git commit -m "Fixed UI Error and created helper function" (YES)
